### PR TITLE
fix #8

### DIFF
--- a/src/components/Chat.vue
+++ b/src/components/Chat.vue
@@ -17,6 +17,7 @@
               : `${message.username}(Guest${message.order})님이 퇴장하셨습니다.`
           }}
         </li>
+        <li v-if="state.isDisconnected">서버가 닫혔습니다.</li>
       </ol>
     </div>
 
@@ -61,7 +62,7 @@ export default {
       messages: [],
       userCount: 0,
       userList: [],
-      userId: $socket.id,
+      isDisconnected: true,
     });
 
     watch(
@@ -76,7 +77,7 @@ export default {
 
       $socket.emit("chat", {
         message: state.inputMessage,
-        userId: state.userId,
+        userId: $socket.id,
       });
       state.inputMessage = "";
     }
@@ -85,6 +86,9 @@ export default {
       $socket.emit("joinUser", username.value);
       $socket.emit("getCount");
 
+      $socket.on("connect", () => {
+        state.isDisconnected = false;
+      });
       $socket.on("joinUser", ({ username, order }) => {
         state.messages.push({ username, order, type: "welcome" });
       });
@@ -104,6 +108,10 @@ export default {
           order,
           type: "chat",
         });
+      });
+      $socket.on("disconnect", () => {
+        alert("서버가 닫혔습니다.");
+        state.isDisconnected = true;
       });
     });
 


### PR DESCRIPTION
Client socket.id의 Property가 간헐적으로 현재 상태를 반영하지 못 한 이유는 굳이 state에서 초기화 할 떄 userId를 빈 문자열로 선언한 뒤 socket에서 connect 이벤트가 발생하면 socket.id를 state.userId에 담았기 때문이었습니다.

```vue
<script>
...
const state = {
  ...
  userId: state.userId,
  ...
}

$socket.on("connect", () => {
  userId = $socket.id;
});

...
</script>
```

하지만 $socket.id는 template에서 쓰이지 않고 script 내에서만 쓰이기 떄문에 굳이 state에 userId를 선언해서 return할 필요 없이, 그냥 script 내에서 바로바로 $socket.id를 불러오니 해결되었습니다.

```vue
// Chat.vue
<script>
$socket.emit("chat", {
  message: state.inputMessage,
  userId: $socket.id,
});
</script>
```

Client socket의 인스턴스의 on 메소드를 사용해서 서버가 열리면 isDisconnected state에 false를, 닫히면 true를 할당해서 서버가 닫혔을 때에 서버가 닫혔다는 메시지가 채팅방에 표시되게 했습니다.
또 서버가 닫힐 때 alert을 화면에 띄워 서버가 닫혔다는 것을 사용자에게 알립니다.

굳이 둘 다 적용한 이유는 유저가 alert을 닫은 뒤에 서버가 닫혔다는 사실을 인지하기가 힘들 것으로 판단되었기 때문입니다.
추후 Chat.vue에 대한 CSS 작업이 모두 끝나면 서버가 닫힌 것을 인지하게 할 UI를 추가해야 할 필요가 있어보입니다.

이상입니다.